### PR TITLE
Removes display of "Performance"

### DIFF
--- a/src/Lib/Presenter/Display/CommandLineDisplay.php
+++ b/src/Lib/Presenter/Display/CommandLineDisplay.php
@@ -96,11 +96,6 @@ class CommandLineDisplay extends Display
 
         // Print art
         $this->liveOrStack(PHP_EOL
-            . "  ___          __                                " . PHP_EOL
-            . " | _ \___ _ _ / _|___ _ _ _ __  __ _ _ _  __ ___ " . PHP_EOL
-            . " |  _/ -_) '_|  _/ _ \ '_| '  \/ _` | ' \/ _/ -_)" . PHP_EOL
-            . " |_| \___|_| |_| \___/_| |_|_|_\__,_|_||_\__\___|" . PHP_EOL
-            . PHP_EOL
             . " Create by B. van hoekelen " . $this->color('green', 'v' . PerformanceHandler::VERSION)  . " PHP " . $this->color('green', 'v'. phpversion()) . $liveIndication . PHP_EOL
             . " Max memory " . ini_get("memory_limit") . " max, execution time " . ini_get('max_execution_time') . " sec on " . date('Y-m-d H:i:s') . PHP_EOL
             . PHP_EOL);


### PR DESCRIPTION
Hey buddy.

Your project is really interesting. Thanks for making him available for everyone.

This pull request addresses the Command Line display. Removing the big display of the word "Performance". I my opinion fits quite bad in some some terminals and do not introduce nothing important on the results.

Before:
<img width="831" alt="screenshot 2017-04-16 19 37 31" src="https://cloud.githubusercontent.com/assets/5457236/25072981/63f21908-22dc-11e7-9a4f-221317452ba1.png">

After:

<img width="977" alt="screenshot 2017-04-16 19 40 28" src="https://cloud.githubusercontent.com/assets/5457236/25072984/91b90c02-22dc-11e7-875c-b3dab8eafbed.png">
